### PR TITLE
Patch for Husky v9

### DIFF
--- a/.secret-scan/secret-scan.js
+++ b/.secret-scan/secret-scan.js
@@ -281,7 +281,7 @@ function getRepoRoot() {
 function checkGitHooks() {
   checkGitVersion();
 
-  const expectedHooksPath = ".husky";
+  const expectedHooksPath = ".husky/_";
   const command = /** @type {const} */ (["git", "config", "--get", "core.hooksPath"]);
   const helpMsg = `Husky has not installed the required Git hooks. Run "npm run prepare" and try again.`;
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Initialize your repository's `.gitignore` with the Node.js template from [`githu
    npm install --save-dev husky
 
    # If necessary, change ".." in both commands to refer to the repository's root directory.
-   npm pkg set scripts.prepare="cd .. && husky install .husky"
+   npm pkg set scripts.prepare="cd .. && husky"
    npm pkg set scripts.check-git-hooks="cd .. && node .secret-scan/secret-scan.js -- --check-git-hooks"
 
    # Install Git hooks.


### PR DESCRIPTION
Husky v9 made some breaking changes, namely deprecating the `husky install` command and apparently changing the structure of the .husky directory. (`https://github.com/typicode/husky/releases/tag/v9.0.1`)

This PR updates the expected hooks path in the script that checks hooks are installed and updates the package.json `prepare` script.